### PR TITLE
INTER-232-IconComponent - 긴급 size속성 추가 PR

### DIFF
--- a/src/app/components/icon/Icon.tsx
+++ b/src/app/components/icon/Icon.tsx
@@ -1121,13 +1121,11 @@ const icons: Record<IconName, IconComponent> = {
 
 export const Icon = ({
   name,
-  width,
-  height,
   className,
   strokeWidth,
   stroke,
   fill,
-  viewBox,
+  size,
   ...props
 }: IIconProps) => {
   const IconComponent = icons[name];
@@ -1139,13 +1137,13 @@ export const Icon = ({
 
   return (
     <IconComponent
-      width={width}
-      height={height}
+      width={size}
+      height={size}
       className={className}
       strokeWidth={strokeWidth}
       stroke={stroke}
       fill={fill}
-      viewBox={viewBox}
+      viewBox={`0 0 ${size} ${size}`}
       {...props}
     />
   );

--- a/src/app/components/icon/Icon.tsx
+++ b/src/app/components/icon/Icon.tsx
@@ -1063,6 +1063,7 @@ const CloseIcon = (props: SVGProps<SVGSVGElement>) => {
       viewBox={viewBox || "0 0 28 28"}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      className="w-full h-full object-cover path:w-full path:g-full"
       {...restProps}
     >
       <path
@@ -1143,7 +1144,6 @@ export const Icon = ({
       strokeWidth={strokeWidth}
       stroke={stroke}
       fill={fill}
-      viewBox={`0 0 ${size} ${size}`}
       {...props}
     />
   );

--- a/src/app/components/icon/Icon.tsx
+++ b/src/app/components/icon/Icon.tsx
@@ -1127,6 +1127,9 @@ export const Icon = ({
   stroke,
   fill,
   size,
+  width,
+  height,
+  viewBox,
   ...props
 }: IIconProps) => {
   const IconComponent = icons[name];
@@ -1138,12 +1141,13 @@ export const Icon = ({
 
   return (
     <IconComponent
-      width={size}
-      height={size}
+      width={size || width}
+      height={size || height}
       className={className}
       strokeWidth={strokeWidth}
       stroke={stroke}
       fill={fill}
+      viewBox={viewBox}
       {...props}
     />
   );

--- a/src/app/components/icon/icon.type.ts
+++ b/src/app/components/icon/icon.type.ts
@@ -51,6 +51,9 @@ export interface IIconProps extends Omit<SVGProps<SVGSVGElement>, "name"> {
   stroke?: string;
   fill?: string;
   size?: number;
+  width?: number;
+  height ?: number;
+  viewBox ?: string;
 }
 
 export type IconComponent = (props: SVGProps<SVGSVGElement>) => React.ReactElement;

--- a/src/app/components/icon/icon.type.ts
+++ b/src/app/components/icon/icon.type.ts
@@ -44,18 +44,13 @@ export type IconName =
   | "codepen"
   | "close";
 
-
 export interface IIconProps extends Omit<SVGProps<SVGSVGElement>, "name"> {
   name: IconName;
-  width?: number;
-  height?: number;
   className?: string;
   strokeWidth?: number;
   stroke?: string;
   fill?: string;
-  viewBox?: string;
+  size?: number;
 }
 
 export type IconComponent = (props: SVGProps<SVGSVGElement>) => React.ReactElement;
-
-

--- a/src/app/components/icon/page.tsx
+++ b/src/app/components/icon/page.tsx
@@ -77,6 +77,9 @@ export default function IconGalleryPage() {
           <Icon name="typescript" width={50} height={50} />
           <Icon name="report" width={50} height={50} stroke="var(--color-incorrect)" />
           <Icon name="plus" width={50} height={50} fill="var(--color-border)" />
+          <Icon name="close" size={50} fill="var(--color-border)" />
+          <Icon name="close" size={140} fill="var(--color-border)" />
+          <Icon name="close" size={20} fill="var(--color-border)" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

ex) INTER-232-IconComponent-> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

- 크기 조정이 올바르게 되도록 viewbox 크기를 고정하고, width와 height를 size라는 props로 통일시켜 사용성 향상

### 테스트 결과 (선택)

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="267" alt="image" src="https://github.com/user-attachments/assets/ab85a325-a978-498c-af08-72b326dcfc49" />


### 스크린샷 (선택)

### 리뷰 요구사항(선택)
