### PR TITLE
ISSUE-48-AddPseudoTailwindClasses-전후문자선택자에 대한 커스텀 클래스 추가 정의 

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -22,6 +22,8 @@
   --font-bold-40: 700 2.5rem/1.2 "Pretendard", sans-serif;
   --font-bold-38: 700 2.375rem/1.2 "Pretendard", sans-serif;
   --font-bold-32: 700 2rem/1.2 "Pretendard", sans-serif;
+  --font-bold-28: 700 1.75rem/1.2 "Pretendard", sans-serif;
+  --font-bold-24: 700 1.5rem/1.2 "Pretendard", sans-serif;
   --font-bold-18: 700 1.125rem/1.2 "Pretendard", sans-serif;
   --font-bold-14: 700 0.875rem/1.2 "Pretendard", sans-serif;
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -19,6 +19,12 @@
   .font-bold-32 {
     font: var(--font-bold-32);
   }
+  .font-bold-28 {
+    font: var(--font-bold-28);
+  }
+  .font-bold-24 {
+    font: var(--font-bold-24);
+  }
   .font-bold-18 {
     font: var(--font-bold-18);
   }
@@ -76,6 +82,256 @@
     font: var(--font-medium-8);
   }
 
+  /* After classes */
+  .after\:font-bold-56 {
+    &::after {
+      font: var(--font-bold-56);
+    }
+  }
+  .after\:font-bold-48 {
+    &::after {
+      font: var(--font-bold-48);
+    }
+  }
+  .after\:font-bold-40 {
+    &::after {
+      font: var(--font-bold-40);
+    }
+  }
+  .after\:font-bold-38 {
+    &::after {
+      font: var(--font-bold-38);
+    }
+  }
+  .after\:font-bold-32 {
+    &::after {
+      font: var(--font-bold-32);
+    }
+  }
+  .after\:font-bold-28 {
+    &::after {
+      font: var(--font-bold-28);
+    }
+  }
+  .after\:font-bold-24 {
+    &::after {
+      font: var(--font-bold-24);
+    }
+  }
+  .after\:font-bold-18 {
+    &::after {
+      font: var(--font-bold-18);
+    }
+  }
+  .after\:font-bold-14 {
+    &::after {
+      font: var(--font-bold-14);
+    }
+  }
+
+  .after\:font-sb-28 {
+    &::after {
+      font: var(--font-sb-28);
+    }
+  }
+  .after\:font-sb-24 {
+    &::after {
+      font: var(--font-sb-24);
+    }
+  }
+  .after\:font-sb-20 {
+    &::after {
+      font: var(--font-sb-20);
+    }
+  }
+  .after\:font-sb-18 {
+    &::after {
+      font: var(--font-sb-18);
+    }
+  }
+  .after\:font-sb-16 {
+    &::after {
+      font: var(--font-sb-16);
+    }
+  }
+  .after\:font-sb-14 {
+    &::after {
+      font: var(--font-sb-14);
+    }
+  }
+  .after\:font-sb-12 {
+    &::after {
+      font: var(--font-sb-12);
+    }
+  }
+
+  .after\:font-regular-26 {
+    &::after {
+      font: var(--font-regular-26);
+    }
+  }
+  .after\:font-regular-24 {
+    &::after {
+      font: var(--font-regular-24);
+    }
+  }
+  .after\:font-regular-18 {
+    &::after {
+      font: var(--font-regular-18);
+    }
+  }
+  .after\:font-regular-16 {
+    &::after {
+      font: var(--font-regular-16);
+    }
+  }
+  .after\:font-regular-14 {
+    &::after {
+      font: var(--font-regular-14);
+    }
+  }
+
+  .after\:font-medium-12 {
+    &::after {
+      font: var(--font-medium-12);
+    }
+  }
+  .after\:font-medium-10 {
+    &::after {
+      font: var(--font-medium-10);
+    }
+  }
+  .after\:font-medium-8 {
+    &::after {
+      font: var(--font-medium-8);
+    }
+  }
+
+  /* Before classes */
+  .before\:font-bold-56 {
+    &::before {
+      font: var(--font-bold-56);
+    }
+  }
+  .before\:font-bold-48 {
+    &::before {
+      font: var(--font-bold-48);
+    }
+  }
+  .before\:font-bold-40 {
+    &::before {
+      font: var(--font-bold-40);
+    }
+  }
+  .before\:font-bold-38 {
+    &::before {
+      font: var(--font-bold-38);
+    }
+  }
+  .before\:font-bold-32 {
+    &::before {
+      font: var(--font-bold-32);
+    }
+  }
+  .before\:font-bold-28 {
+    &::before {
+      font: var(--font-bold-28);
+    }
+  }
+  .before\:font-bold-24 {
+    &::before {
+      font: var(--font-bold-24);
+    }
+  }
+  .before\:font-bold-18 {
+    &::before {
+      font: var(--font-bold-18);
+    }
+  }
+  .before\:font-bold-14 {
+    &::before {
+      font: var(--font-bold-14);
+    }
+  }
+
+  .before\:font-sb-28 {
+    &::before {
+      font: var(--font-sb-28);
+    }
+  }
+  .before\:font-sb-24 {
+    &::before {
+      font: var(--font-sb-24);
+    }
+  }
+  .before\:font-sb-20 {
+    &::before {
+      font: var(--font-sb-20);
+    }
+  }
+  .before\:font-sb-18 {
+    &::before {
+      font: var(--font-sb-18);
+    }
+  }
+  .before\:font-sb-16 {
+    &::before {
+      font: var(--font-sb-16);
+    }
+  }
+  .before\:font-sb-14 {
+    &::before {
+      font: var(--font-sb-14);
+    }
+  }
+  .before\:font-sb-12 {
+    &::before {
+      font: var(--font-sb-12);
+    }
+  }
+
+  .before\:font-regular-26 {
+    &::before {
+      font: var(--font-regular-26);
+    }
+  }
+  .before\:font-regular-24 {
+    &::before {
+      font: var(--font-regular-24);
+    }
+  }
+  .before\:font-regular-18 {
+    &::before {
+      font: var(--font-regular-18);
+    }
+  }
+  .before\:font-regular-16 {
+    &::before {
+      font: var(--font-regular-16);
+    }
+  }
+  .before\:font-regular-14 {
+    &::before {
+      font: var(--font-regular-14);
+    }
+  }
+
+  .before\:font-medium-12 {
+    &::before {
+      font: var(--font-medium-12);
+    }
+  }
+  .before\:font-medium-10 {
+    &::before {
+      font: var(--font-medium-10);
+    }
+  }
+  .before\:font-medium-8 {
+    &::before {
+      font: var(--font-medium-8);
+    }
+  }
+
   /* Media query classes */
   @media screen and (min-width: 768px) {
     .md\:font-bold-56 {
@@ -92,6 +348,12 @@
     }
     .md\:font-bold-32 {
       font: var(--font-bold-32);
+    }
+    .md\:font-bold-28 {
+      font: var(--font-bold-28);
+    }
+    .md\:font-bold-24 {
+      font: var(--font-bold-24);
     }
     .md\:font-bold-18 {
       font: var(--font-bold-18);
@@ -146,6 +408,256 @@
     }
     .md\:font-medium-8 {
       font: var(--font-medium-8);
+    }
+
+    /* Media query before classes */
+    .md\:before\:font-bold-56 {
+      &::before {
+        font: var(--font-bold-56);
+      }
+    }
+    .md\:before\:font-bold-48 {
+      &::before {
+        font: var(--font-bold-48);
+      }
+    }
+    .md\:before\:font-bold-40 {
+      &::before {
+        font: var(--font-bold-40);
+      }
+    }
+    .md\:before\:font-bold-38 {
+      &::before {
+        font: var(--font-bold-38);
+      }
+    }
+    .md\:before\:font-bold-32 {
+      &::before {
+        font: var(--font-bold-32);
+      }
+    }
+    .md\:before\:font-bold-28 {
+      &::before {
+        font: var(--font-bold-28);
+      }
+    }
+    .md\:before\:font-bold-24 {
+      &::before {
+        font: var(--font-bold-24);
+      }
+    }
+    .md\:before\:font-bold-18 {
+      &::before {
+        font: var(--font-bold-18);
+      }
+    }
+    .md\:before\:font-bold-14 {
+      &::before {
+        font: var(--font-bold-14);
+      }
+    }
+
+    .md\:before\:font-sb-28 {
+      &::before {
+        font: var(--font-sb-28);
+      }
+    }
+    .md\:before\:font-sb-24 {
+      &::before {
+        font: var(--font-sb-24);
+      }
+    }
+    .md\:before\:font-sb-20 {
+      &::before {
+        font: var(--font-sb-20);
+      }
+    }
+    .md\:before\:font-sb-18 {
+      &::before {
+        font: var(--font-sb-18);
+      }
+    }
+    .md\:before\:font-sb-16 {
+      &::before {
+        font: var(--font-sb-16);
+      }
+    }
+    .md\:before\:font-sb-14 {
+      &::before {
+        font: var(--font-sb-14);
+      }
+    }
+    .md\:before\:font-sb-12 {
+      &::before {
+        font: var(--font-sb-12);
+      }
+    }
+
+    .md\:before\:font-regular-26 {
+      &::before {
+        font: var(--font-regular-26);
+      }
+    }
+    .md\:before\:font-regular-24 {
+      &::before {
+        font: var(--font-regular-24);
+      }
+    }
+    .md\:before\:font-regular-18 {
+      &::before {
+        font: var(--font-regular-18);
+      }
+    }
+    .md\:before\:font-regular-16 {
+      &::before {
+        font: var(--font-regular-16);
+      }
+    }
+    .md\:before\:font-regular-14 {
+      &::before {
+        font: var(--font-regular-14);
+      }
+    }
+
+    .md\:before\:font-medium-12 {
+      &::before {
+        font: var(--font-medium-12);
+      }
+    }
+    .md\:before\:font-medium-10 {
+      &::before {
+        font: var(--font-medium-10);
+      }
+    }
+    .md\:before\:font-medium-8 {
+      &::before {
+        font: var(--font-medium-8);
+      }
+    }
+
+    /* Media query after classes */
+    .md\:after\:font-bold-56 {
+      &::after {
+        font: var(--font-bold-56);
+      }
+    }
+    .md\:after\:font-bold-48 {
+      &::after {
+        font: var(--font-bold-48);
+      }
+    }
+    .md\:after\:font-bold-40 {
+      &::after {
+        font: var(--font-bold-40);
+      }
+    }
+    .md\:after\:font-bold-38 {
+      &::after {
+        font: var(--font-bold-38);
+      }
+    }
+    .md\:after\:font-bold-32 {
+      &::after {
+        font: var(--font-bold-32);
+      }
+    }
+    .md\:after\:font-bold-28 {
+      &::after {
+        font: var(--font-bold-28);
+      }
+    }
+    .md\:after\:font-bold-24 {
+      &::after {
+        font: var(--font-bold-24);
+      }
+    }
+    .md\:after\:font-bold-18 {
+      &::after {
+        font: var(--font-bold-18);
+      }
+    }
+    .md\:after\:font-bold-14 {
+      &::after {
+        font: var(--font-bold-14);
+      }
+    }
+
+    .md\:after\:font-sb-28 {
+      &::after {
+        font: var(--font-sb-28);
+      }
+    }
+    .md\:after\:font-sb-24 {
+      &::after {
+        font: var(--font-sb-24);
+      }
+    }
+    .md\:after\:font-sb-20 {
+      &::after {
+        font: var(--font-sb-20);
+      }
+    }
+    .md\:after\:font-sb-18 {
+      &::after {
+        font: var(--font-sb-18);
+      }
+    }
+    .md\:after\:font-sb-16 {
+      &::after {
+        font: var(--font-sb-16);
+      }
+    }
+    .md\:after\:font-sb-14 {
+      &::after {
+        font: var(--font-sb-14);
+      }
+    }
+    .md\:after\:font-sb-12 {
+      &::after {
+        font: var(--font-sb-12);
+      }
+    }
+
+    .md\:after\:font-regular-26 {
+      &::after {
+        font: var(--font-regular-26);
+      }
+    }
+    .md\:after\:font-regular-24 {
+      &::after {
+        font: var(--font-regular-24);
+      }
+    }
+    .md\:after\:font-regular-18 {
+      &::after {
+        font: var(--font-regular-18);
+      }
+    }
+    .md\:after\:font-regular-16 {
+      &::after {
+        font: var(--font-regular-16);
+      }
+    }
+    .md\:after\:font-regular-14 {
+      &::after {
+        font: var(--font-regular-14);
+      }
+    }
+
+    .md\:after\:font-medium-12 {
+      &::after {
+        font: var(--font-medium-12);
+      }
+    }
+    .md\:after\:font-medium-10 {
+      &::after {
+        font: var(--font-medium-10);
+      }
+    }
+    .md\:after\:font-medium-8 {
+      &::after {
+        font: var(--font-medium-8);
+      }
     }
   }
 }


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

ISSUE-48-AddPseudoTailwindClasses -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 리펙토링

### 작업 내용

- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- 전후문자선택자에 대한 커스텀 클래스 추가 정의 
- bold 커스텀 클래스 2가지 추가 (24px, 28px)

Resolves #48 