### PR TITLE
ISSUE-83-AddOnOffButtonTextArea - textarea 컴포넌트 버튼 opacity-0 스타일 추가 #83

### DIFF
--- a/src/app/components/textarea/Textarea.tsx
+++ b/src/app/components/textarea/Textarea.tsx
@@ -28,7 +28,7 @@ export const Textarea = ({ name, id, type, maxLength, placeholder, noButton }: I
           </span>
           <Button
             type="button"
-            className={`${buttonVariants({ size: "sm", color: "borderGray", hover: true })} px-4 py-1.5 ${noButton && "opacity-0"}`}
+            className={`${buttonVariants({ size: "sm", color: "borderGray", hover: true })} px-4 py-1.5 ${noButton && "hidden"}`}
           >
             작성
           </Button>

--- a/src/app/components/textarea/Textarea.tsx
+++ b/src/app/components/textarea/Textarea.tsx
@@ -5,7 +5,7 @@ import { ITextareaProps } from "./textarea.type";
 import { wrapperVariants, textareaVariants } from "./textarea.variants";
 import { Button, buttonVariants } from "../button";
 
-export const Textarea = ({ name, id, type, maxLength, placeholder }: ITextareaProps) => {
+export const Textarea = ({ name, id, type, maxLength, placeholder, noButton }: ITextareaProps) => {
   const [count, setCount] = useState(0);
   const onTextareaHandler: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
     setCount(e.target.value.length);
@@ -28,7 +28,7 @@ export const Textarea = ({ name, id, type, maxLength, placeholder }: ITextareaPr
           </span>
           <Button
             type="button"
-            className={`${buttonVariants({ size: "sm", color: "borderGray", hover: true })} px-4 py-1.5`}
+            className={`${buttonVariants({ size: "sm", color: "borderGray", hover: true })} px-4 py-1.5 ${noButton && "opacity-0"}`}
           >
             작성
           </Button>

--- a/src/app/components/textarea/page.tsx
+++ b/src/app/components/textarea/page.tsx
@@ -18,6 +18,17 @@ export default function TextareaTestPage() {
         />
       </div>
 
+      <div className="h-25 md:h-54">
+        <Textarea
+          name="comment"
+          id="comment"
+          type="comment"
+          maxLength={500}
+          placeholder="댓글을 입력하세요.."
+          noButton={true}
+        />
+      </div>
+
       {/* type="reply" */}
       <div className="h-57 px-7.5 pt-8.5 pb-5.5 bg-[#f5f5f5] flex flex-col gap-3.5">
         <Textarea name="reply" id="reply" type="reply" placeholder="댓글을 입력하세요.." />

--- a/src/app/components/textarea/textarea.type.ts
+++ b/src/app/components/textarea/textarea.type.ts
@@ -6,4 +6,5 @@ export interface ITextareaProps {
   type: TextareaType;
   maxLength?: number;
   placeholder: string;
+  noButton?: boolean;
 }


### PR DESCRIPTION
## PR 제목

ISSUE-83-AddOnOffButtonTextArea - textarea 컴포넌트 버튼 opacity-0 스타일 추가

## PR 본문

### 반영 브랜치

ex) ISSUE-83-AddOnOffButtonTextArea -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 리펙토링

### 작업 내용

- noButton prop를 추가해서 opacity로 hidden 표현

### 스크린샷 (선택)
ISSUE-83-AddOnOffButtonTextArea
